### PR TITLE
docs: add arXiv 2602.23295 to Latest Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In recent years (2022-now), dataset distillation has gained increasing attention
 + :book: `bibtex`
 
 ## Latest Updates
++ [2026/03/06] [arXiv:2602.23295](https://arxiv.org/abs/2602.23295) (CVPR 2026)
 + [2026/02/26] [Dataset Color Quantization: A Training-Oriented Framework for Dataset-Level Compression](https://arxiv.org/abs/2602.20650) (Chenyue Yu et al., ICLR 2026) [:book:](./citations/yu2026dcq.txt)
 + [2026/02/26] [Multimodal Dataset Distillation Made Simple by Prototype-Guided Data Synthesis](https://arxiv.org/abs/2602.19756) (Junhyeok Choi et al., ICLR 2026) [:octocat:](https://github.com/junhyeok9712/PDS) [:book:](./citations/choi2026multi.txt)
 + [2026/02/26] [CoDA: From Text-to-Image Diffusion Models to Training-Free Dataset Distillation](https://arxiv.org/abs/2512.03844) (Letian Zhou et al., ICLR 2026) [:octocat:](https://github.com/zzzlt422/CoDA) [:book:](./citations/zhou2026coda.txt)


### PR DESCRIPTION
### Motivation
- Add a new Latest Updates entry so the README reflects the newly announced paper `arXiv:2602.23295` (tagged as CVPR 2026) dated today; Skill used: none (no specialized skill needed). 

### Description
- Inserted a single line at the top of the `## Latest Updates` section in `README.md`: `[2026/03/06] [arXiv:2602.23295](https://arxiv.org/abs/2602.23295) (CVPR 2026)`, and committed the change with message `docs: add CVPR 2026 paper to latest updates`.

### Testing
- Confirmed the addition appears in `README.md` via `nl -ba README.md | sed -n '20,40p'` and `git status --short`, and verified the commit was created; an attempt to fetch arXiv metadata via `curl` returned HTTP 403 so metadata was not auto-populated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2a3766508325b6a5e368f7d7d977)